### PR TITLE
fix: use entry.lspconfig_name instead of entry.mason_pkg for the ensure_installed list

### DIFF
--- a/src/codegen/plugins/lsp.rs
+++ b/src/codegen/plugins/lsp.rs
@@ -8,7 +8,7 @@ pub fn generate(state: &WizardState) -> String {
 
     for &lang in &state.languages {
         for entry in lsp_entries_for(lang) {
-            let pkg = format!("    \"{}\", -- {}", entry.mason_pkg, entry.note);
+            let pkg = format!("    \"{}\", -- {}", entry.lspconfig_name, entry.note);
             if !mason_pkgs.contains(&pkg) {
                 mason_pkgs.push(pkg);
             }


### PR DESCRIPTION
The bug: lsp.rs codegen puts entry.mason_pkg directly into ensure_installed, but ensure_installed requires lspconfig server names (e.g. rust_analyzer, ts_ls), not mason package names (e.g. rust-analyzer, typescript-language-server).

Fix: In lsp.rs use entry.lspconfig_name instead of entry.mason_pkg for the ensure_installed list.

Closes: #3 